### PR TITLE
feat(sort): add route ranking

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,99 @@ export function RoutesLoader(
     return results;
   };
 
-  const files = recursive ? walk(loadPath) : fs.readdirSync(loadPath);
+  let files = recursive ? walk(loadPath) : fs.readdirSync(loadPath);
+
+  /**
+   * =======================================
+   * ROUTE RANKING
+   */
+
+  // From lowest (0) to highest (4) score.
+  const SCORES = {
+    EMPTY: 0,
+    INDEX: 1,
+    SPLAT: 2, // wildcard
+    OPTIONAL: 3,
+    DYNAMIC: 4, // route params
+    STATIC: 5, // named routes
+  };
+
+  /**
+   * These is similar to react-router score algorithm:
+   * https://github.com/remix-run/react-router/blob/6b44e99f0b659428ce2ec8d5098e90c7fddda2c5/packages/react-router/lib/router.ts#L243-L274
+   *
+   * The difference being; this algorithm compares segment to segment instead of
+   * computing the score for the entire route.
+   */
+  function getSegmentScore(segment: string = "") {
+    segment = segment.replace(path.extname(segment), ""); // remove extension
+
+    if (!segment) {
+      return SCORES.EMPTY;
+    } else if (/^index$/.test(segment)) {
+      return SCORES.INDEX; // index files should be run last for error handling
+    } else if (segment === "*") {
+      return SCORES.SPLAT;
+    } else if (/\?$/.test(segment)) {
+      return SCORES.OPTIONAL; // optional, i.e. ends with "?"
+    } else if (/^:/.test(segment)) {
+      return SCORES.DYNAMIC; // params, i.e. starts with ":"
+    }
+
+    return SCORES.STATIC; // anything else (i.e. named routes)
+  }
+
+  /**
+   * This sort algorithm compares each route segment by segment to determine
+   * its priority. The higher the score of the segment; the earlier it will be
+   * added to the routes.
+   *
+   * For example, named routes should have higher priority over :params,
+   * otherwise, the named route will never be hit. Similarly, index files in
+   * any directory should be executed last to allow adding error handlers, etc.
+   *
+   * Sample:
+   *  - '/api/articles/:year/december/:day.js', // december > :month
+   *  - '/api/articles/:year/:month/:day.js', // :month > :month?
+   *  - '/api/articles/:year/:month?.js', // :month? > *
+   *  - '/api/articles/:year/*.js', // * > index
+   *  - '/api/articles/:year/index.js', // last to be executed in '/api/articles/:year'
+   *  - '/api/articles/index.js',
+   *  - '/api/items/thing.js',
+   *  - '/api/items/:type.js',
+   *  - '/api/items/*.js',
+   *  - '/api/items/index.js',
+   *  - '/api/index.js',
+   *  - '/index.js'
+   */
+  const segmentScores: { [key: string]: number } = {}; // memoize segment scores
+  files.sort((entry_a: string, entry_b: string) => {
+    const split_a = entry_a.split("/");
+    const split_b = entry_b.split("/");
+    const maxNestingLevel = Math.max(split_a.length, split_b.length);
+    for (let i = 0; i < maxNestingLevel; i++) {
+      const folder_a = split_a[i];
+      const folder_b = split_b[i];
+      const spec_a = (segmentScores[folder_a] =
+        segmentScores[folder_a] || getSegmentScore(folder_a));
+      const spec_b = (segmentScores[folder_b] =
+        segmentScores[folder_b] || getSegmentScore(folder_b));
+      if (folder_a === folder_b) {
+        continue;
+      } else if (spec_a === SCORES.STATIC && spec_b === SCORES.STATIC) {
+        return folder_a < folder_b ? -1 : 1; // alphabetical
+      } else if (spec_a === spec_b) {
+        continue;
+      } else {
+        return spec_b - spec_a;
+      }
+    }
+    return 0; // routes have same score
+  });
+
+  /**
+   * =======================================
+   */
 
   for (const entry of files) {
     const file = recursive

--- a/test/index.ts
+++ b/test/index.ts
@@ -4,16 +4,16 @@ import { expect } from "chai";
 describe("#load routes", () => {
   it("load route", () => {
     const routes = RoutesLoader("./test/routes", { recursive: false }).stack;
-    expect(routes[0].route.path).to.equal("/");
-    expect(routes[1].route.path).to.equal("/typescript");
+    expect(routes[0].route.path).to.equal("/typescript");
+    expect(routes[1].route.path).to.equal("/");
   });
 });
 
 describe("#load routes recursive", () => {
   it("load route recursive", () => {
     const routes = RoutesLoader("./test/routes", { recursive: true }).stack;
-    expect(routes[0].route.path).to.equal("/");
-    expect(routes[1].route.path).to.equal("/recursive");
-    expect(routes[2].route.path).to.equal("/typescript");
+    expect(routes[0].route.path).to.equal("/recursive");
+    expect(routes[1].route.path).to.equal("/typescript");
+    expect(routes[2].route.path).to.equal("/");
   });
 });

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,14 +1,19 @@
-import { RoutesLoader } from '../src/index';
-import { expect } from 'chai';
+import { RoutesLoader } from "../src/index";
+import { expect } from "chai";
 
-describe('#load routes', () => {
-	it('load route', () => {
-		expect(RoutesLoader('./test/routes', false).stack[0].route.path).to.equal('/');
-	});
+describe("#load routes", () => {
+  it("load route", () => {
+    const routes = RoutesLoader("./test/routes", { recursive: false }).stack;
+    expect(routes[0].route.path).to.equal("/");
+    expect(routes[1].route.path).to.equal("/typescript");
+  });
 });
 
-describe('#load routes recursive', () => {
-	it('load route recursive', () => {
-		expect(RoutesLoader('./test/routes', true).stack[1].route.path).to.equal('/recursive');
-	});
+describe("#load routes recursive", () => {
+  it("load route recursive", () => {
+    const routes = RoutesLoader("./test/routes", { recursive: true }).stack;
+    expect(routes[0].route.path).to.equal("/");
+    expect(routes[1].route.path).to.equal("/recursive");
+    expect(routes[2].route.path).to.equal("/typescript");
+  });
 });


### PR DESCRIPTION
Rank routes based on segment by segment comparison.

Based on this tweet: https://twitter.com/pgarciacamou/status/1564701443197571072?s=20&t=UIUrjN2sQBAmSK96_zjKig

> The React Router V6 score algorithm works as follows:
> 1. Static segments (aka, named routes) have the highest priority: 10 points.
> 2. Dynamic segments (aka, route params) have the second highest priority: 3 points.
> 3. Index routes come third with a priority of: 2 points.
> 4. Empty segments have a priority of: 1 point.
> 5. The number of segments in a route has a priority of: 1 point.
> 6. Routes with at least one splat segment (aka, wildcards) are penalized with -2 points.
> 7. Lastly, if two scores are the same it chooses the first one.

But the scores are a bit different:

1. Static segments (aka, named routes) have the highest priority: 5.
2. Dynamic segments (aka, route params) have the second highest priority: 4.
3. Optional segments (aka, ends with "?)" have a priority of: 3. **This is not in react-router**.
4. Splat segments (aka, wildcards) have a priority of: 3. **Instead of penalizing -2 in react-router**.
5. Index segments (aka, index.js files) have a priority of: 1.
6. Empty segments have a priority of: 0.

This is because mine compares segment by segment instead of getting a score for the entire route, like react-router.

For example:

```js
// from:
[
  '/api/users/:id.js',
  '/api/items/:type.js',
  '/api/items/index.js',
  '/api/items/thing.js',
  '/api/articles/:year?/*.js',
  '/api/articles/:year?/:month?.js',
  '/api/articles/:year?/index.js',
  '/api/articles/:year/december/:day.js',
  '/api/articles/:year/:month/:day.js',
  '/api/articles/index.js',
  '/api/index.js',
  '/index.js'
]

// to:
[
  '/api/articles/:year/december/:day.js',
  '/api/articles/:year/:month/:day.js',
  '/api/articles/:year?/:month?.js',
  '/api/articles/:year?/*.js',
  '/api/articles/:year?/index.js',
  '/api/articles/index.js',
  '/api/items/thing.js',
  '/api/items/:type.js',
  '/api/items/index.js',
  '/api/users/:id.js',
  '/api/index.js',
  '/index.js'
]
```