### PR TITLE
feat: map directories to actual routes

### DIFF
--- a/src/utils/getRoutesRecursively.ts
+++ b/src/utils/getRoutesRecursively.ts
@@ -1,0 +1,44 @@
+import { IRoute, IRouter } from "express";
+
+type TStack = Array<ILayer>;
+
+export interface ICustomRouter extends IRouter {
+  stack: TStack;
+  __dir_path__: string; // custom property
+}
+
+interface ILayer {
+  handle: ICustomRouter;
+  name: string;
+  regexp: RegExp;
+  route: IRoute;
+  method: string;
+}
+
+export function getRoutesRecursively(router: ICustomRouter) {
+  const path = require("path");
+
+  const currentRoutes = router.stack.filter((layer: ILayer) => layer.route);
+
+  const nestedRouters = router.stack.filter(
+    (stack: ILayer) => stack.name === "router"
+  );
+
+  let routes: Array<string> = [];
+
+  // Routes in current router
+  currentRoutes.forEach((layer: ILayer) => {
+    const method = layer.route.stack && layer.route.stack[0].method;
+    const routePath = layer.route.path;
+    routes.push(
+      `[${method.toUpperCase()}] ${path.join(router.__dir_path__, routePath)}`
+    );
+  });
+
+  // Unpack nested routers recursively
+  nestedRouters.forEach((layer: ILayer) => {
+    routes = routes.concat(getRoutesRecursively(layer.handle));
+  });
+
+  return routes;
+}

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,19 +1,50 @@
 import { RoutesLoader } from "../src/index";
 import { expect } from "chai";
+import { getRoutesRecursively } from "../src/utils/getRoutesRecursively";
 
 describe("#load routes", () => {
   it("load route", () => {
-    const routes = RoutesLoader("./test/routes", { recursive: false }).stack;
-    expect(routes[0].route.path).to.equal("/typescript");
-    expect(routes[1].route.path).to.equal("/");
+    const routes = getRoutesRecursively(
+      RoutesLoader("./routes", { recursive: false, dirname: __dirname })
+    );
+
+    // They must be added in this order following the ranking mechanism
+    ["[GET] /typescript/", "[GET] /typescript/*", "[GET] /"].forEach(
+      (route, index) => {
+        expect(routes[index]).to.equal(route);
+      }
+    );
+  });
+
+  it("load route absolute", () => {
+    const path = require("path");
+    const routes = getRoutesRecursively(
+      RoutesLoader(path.join(__dirname, "routes"), { recursive: false })
+    );
+
+    // They must be added in this order following the ranking mechanism
+    ["[GET] /typescript/", "[GET] /typescript/*", "[GET] /"].forEach(
+      (route, index) => {
+        expect(routes[index]).to.equal(route);
+      }
+    );
   });
 });
 
 describe("#load routes recursive", () => {
   it("load route recursive", () => {
-    const routes = RoutesLoader("./test/routes", { recursive: true }).stack;
-    expect(routes[0].route.path).to.equal("/recursive");
-    expect(routes[1].route.path).to.equal("/typescript");
-    expect(routes[2].route.path).to.equal("/");
+    const routes = getRoutesRecursively(
+      RoutesLoader("./routes", { recursive: true, dirname: __dirname })
+    );
+
+    // They must be added in this order following the ranking mechanism
+    [
+      "[GET] /recursive/",
+      "[GET] /typescript/",
+      "[GET] /typescript/*",
+      "[GET] /",
+    ].forEach((route, index) => {
+      expect(routes[index]).to.equal(route);
+    });
   });
 });

--- a/test/routes/index.js
+++ b/test/routes/index.js
@@ -1,8 +1,5 @@
-export default function(router){
-
-	router.get('/', function(req, res) {
-		res.send('hello');
-	});
-
-	return router;
+export default function (router) {
+  router.get("/", function (req, res) {
+    res.send("hello");
+  });
 }

--- a/test/routes/recursive/index.js
+++ b/test/routes/recursive/index.js
@@ -1,9 +1,5 @@
 export default function (router) {
-
-	router.get('/recursive', function (req, res) {
-		res.send('hello');
-	});
-
-	return router;
+  router.get("/", function (req, res) {
+    res.send("recursive");
+  });
 }
-

--- a/test/routes/typescript.ts
+++ b/test/routes/typescript.ts
@@ -1,10 +1,11 @@
-import { Request, Response, Router } from 'express';
+import { Request, Response, Router } from "express";
 
-export default function (router: Router): Router {
+export default function (router: Router) {
+  router.get("/", (_req: Request, res: Response) => {
+    res.send("typescript");
+  });
 
-    router.get('/typescript', (_req: Request, res: Response) => {
-        res.send('typescript');
-    });
-
-    return router;
+  router.get("*", (_req: Request, res: Response) => {
+    res.send("typescript/any");
+  });
 }


### PR DESCRIPTION
This PR creates internal routers for each directory and uses the actual directory path to map to the internal routes.

For example: 

```
> items
   > :classification
      - :id.js
```

Will actually map to `/items/:classification/:id` without having to internally do it inside the file as the original module required it:  https://github.com/hortopan/expressjs.routes.autoload/blob/2820ced732d8e6c285409875f8d521df612eff91/test/routes/recursive/index.js#L3

Now we would simply do:

```js
module.exports = (router) => {
  router.get('/', () => {})
}
```

And that would automatically map to: `[GET] /items/:classification/:id/` without having to do `router.get('/items/:classification/:id/', () => {})`. Similarly, router.post('/', () => {}) would map to `[POST] /items/:classification/:id/`.

### **Note that we don't have to return the router anymore either.**