### PR TITLE
feat: add log routes feature

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,21 @@
-import { ICustomRouter } from "./utils/getRoutesRecursively";
+import {
+  getRoutesRecursively,
+  ICustomRouter,
+} from "./utils/getRoutesRecursively";
 
 export function RoutesLoader(
   loadPath: string,
-  options: { recursive?: boolean; dirname?: string } = {}
+  options: { recursive?: boolean; dirname?: string; logRoutes?: boolean } = {}
 ): ICustomRouter {
   const recursive: boolean = options.recursive !== false; // defaults to true
   const dirname: string = options.dirname || process.cwd();
+  const logRoutes: boolean = options.logRoutes !== false; // defaults to true
 
   const express = require("express");
   const fs = require("fs");
   const path = require("path");
 
-  let router = express.Router();
+  const router = express.Router();
 
   if (!loadPath) loadPath = "./routes";
 
@@ -37,7 +41,7 @@ export function RoutesLoader(
     return results;
   };
 
-  let files = recursive ? walk(loadPath) : fs.readdirSync(loadPath);
+  const files = recursive ? walk(loadPath) : fs.readdirSync(loadPath);
 
   /**
    * =======================================
@@ -61,7 +65,7 @@ export function RoutesLoader(
    * The difference being; this algorithm compares segment to segment instead of
    * computing the score for the entire route.
    */
-  function getSegmentScore(segment: string = "") {
+  function getSegmentScore(segment: string = ""): number {
     segment = segment.replace(path.extname(segment), ""); // remove extension
 
     if (!segment) {
@@ -163,6 +167,10 @@ export function RoutesLoader(
         );
       }
     }
+  }
+
+  if (logRoutes) {
+    console.log(getRoutesRecursively(router));
   }
 
   return router;

--- a/src/utils/getRoutesRecursively.ts
+++ b/src/utils/getRoutesRecursively.ts
@@ -1,6 +1,6 @@
 import { IRoute, IRouter } from "express";
 
-type TStack = Array<ILayer>;
+type TStack = ILayer[];
 
 export interface ICustomRouter extends IRouter {
   stack: TStack;
@@ -15,7 +15,7 @@ interface ILayer {
   method: string;
 }
 
-export function getRoutesRecursively(router: ICustomRouter) {
+export function getRoutesRecursively(router: ICustomRouter): string[] {
   const path = require("path");
 
   const currentRoutes = router.stack.filter((layer: ILayer) => layer.route);
@@ -24,7 +24,7 @@ export function getRoutesRecursively(router: ICustomRouter) {
     (stack: ILayer) => stack.name === "router"
   );
 
-  let routes: Array<string> = [];
+  let routes: string[] = [];
 
   // Routes in current router
   currentRoutes.forEach((layer: ILayer) => {


### PR DESCRIPTION
Now we are able to do: 

```js
app.use(
  RoutesLoader(path.join(__dirname, "./routes"), {
    logRoutes: false,
  })
);
```

Note that `logRoutes` defaults to `true` because it is valuable information.